### PR TITLE
Add service accounts and pod annotations

### DIFF
--- a/services/bender/templates/serviceaccount.yaml
+++ b/services/bender/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "bender.serviceAccountName" . }}
+  labels:
+    {{- include "bender.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end -}}

--- a/services/bender/templates/statefulset.yaml
+++ b/services/bender/templates/statefulset.yaml
@@ -17,6 +17,9 @@ spec:
       labels:
         {{- include "bender.selectorLabels" . | nindent 8 }}
       annotations:
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         bender/properties-hash: {{ include "bender.propertiesHash" . }}
     spec:
       imagePullSecrets:

--- a/services/bender/values.yaml
+++ b/services/bender/values.yaml
@@ -19,12 +19,14 @@ fullnameOverride: ""
 
 serviceAccount:
   # Specifies whether a service account should be created
-  create: false
+  create: true
   # Annotations to add to the service account
   annotations: {}
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
   name: ""
+
+podAnnotations: {}
 
 podSecurityContext: {}
   # fsGroup: 2000

--- a/services/binbase/templates/_helpers.tpl
+++ b/services/binbase/templates/_helpers.tpl
@@ -52,6 +52,17 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
+Create the name of the service account to use
+*/}}
+{{- define "binbase.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "binbase.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
 Configs hash
 */}}
 {{- define "binbase.propertiesHash" -}}

--- a/services/binbase/templates/deployment.yaml
+++ b/services/binbase/templates/deployment.yaml
@@ -14,10 +14,14 @@ spec:
       labels:
         {{- include "binbase.selectorLabels" . | nindent 8 }}
       annotations:
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         binbase/properties-hash: {{ include "binbase.propertiesHash" . }}
     spec:
       imagePullSecrets:
         - name: {{ .Values.imagePullSecrets.name }}
+      serviceAccountName: {{ include "binbase.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/services/binbase/templates/serviceaccount.yaml
+++ b/services/binbase/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "binbase.serviceAccountName" . }}
+  labels:
+    {{- include "binbase.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end -}}

--- a/services/binbase/values.yaml
+++ b/services/binbase/values.yaml
@@ -15,6 +15,17 @@ fullnameOverride: ""
 podSecurityContext: {}
   # fsGroup: 2000
 
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+
 securityContext: {}
   # capabilities:
   #   drop:

--- a/services/capi-v2/templates/_helpers.tpl
+++ b/services/capi-v2/templates/_helpers.tpl
@@ -52,6 +52,17 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
+Create the name of the service account to use
+*/}}
+{{- define "capi-v2.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "capi-v2.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Create the configs hash
 */}}
 {{- define "capi-v2.propertiesHash" -}}

--- a/services/capi-v2/templates/deployment.yaml
+++ b/services/capi-v2/templates/deployment.yaml
@@ -14,11 +14,15 @@ spec:
       labels:
         {{- include "capi-v2.selectorLabels" . | nindent 8 }}
       annotations:
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         capi-v2/properties-hash: {{ include "capi-v2.propertiesHash" . }}
         capi-v2/secrets-hash: {{ include "capi-v2.secretsHash" . }}
     spec:
       imagePullSecrets:
         - name: {{ .Values.imagePullSecrets.name }}
+      serviceAccountName: {{ include "capi-v2.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       initContainers:

--- a/services/capi-v2/templates/serviceaccount.yaml
+++ b/services/capi-v2/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "capi-v2.serviceAccountName" . }}
+  labels:
+    {{- include "capi-v2.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end -}}

--- a/services/capi-v2/values.yaml
+++ b/services/capi-v2/values.yaml
@@ -19,12 +19,14 @@ fullnameOverride: ""
 
 serviceAccount:
   # Specifies whether a service account should be created
-  create: false
+  create: true
   # Annotations to add to the service account
   annotations: {}
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
   name: ""
+
+podAnnotations: {}
 
 podSecurityContext: {}
   # fsGroup: 2000

--- a/services/cds/templates/deployment.yaml
+++ b/services/cds/templates/deployment.yaml
@@ -14,6 +14,9 @@ spec:
       labels:
         {{- include "cds.selectorLabels" . | nindent 8 }}
       annotations:
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         cds/properties-hash: {{ include "cds.propertiesHash" . }}
     spec:
       imagePullSecrets:

--- a/services/cds/templates/serviceaccount.yaml
+++ b/services/cds/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "cds.serviceAccountName" . }}
+  labels:
+    {{- include "cds.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/services/cds/values.yaml
+++ b/services/cds/values.yaml
@@ -17,12 +17,14 @@ fullnameOverride: ""
 
 serviceAccount:
   # Specifies whether a service account should be created
-  create: false
+  create: true
   # Annotations to add to the service account
   annotations: {}
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
   name: ""
+
+podAnnotations: {}
 
 podSecurityContext: {}
   # fsGroup: 2000

--- a/services/kds/templates/deployment.yaml
+++ b/services/kds/templates/deployment.yaml
@@ -15,6 +15,10 @@ spec:
       {{- include "kds.selectorLabels" . | nindent 6 }}
   template:
     metadata:
+      annotations:
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       labels:
         {{- include "kds.selectorLabels" . | nindent 8 }}
     spec:

--- a/services/kds/templates/serviceaccount.yaml
+++ b/services/kds/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "kds.serviceAccountName" . }}
+  labels:
+    {{- include "kds.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/services/kds/values.yaml
+++ b/services/kds/values.yaml
@@ -17,12 +17,14 @@ fullnameOverride: ""
 
 serviceAccount:
   # Specifies whether a service account should be created
-  create: false
+  create: true
   # Annotations to add to the service account
   annotations: {}
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
   name: ""
+
+podAnnotations: {}
 
 podSecurityContext: {}
   # fsGroup: 2000

--- a/services/machinegun/templates/_helpers.tpl
+++ b/services/machinegun/templates/_helpers.tpl
@@ -63,6 +63,17 @@ Create the name of the service account to use
 {{- end }}
 
 {{/*
+Create the name of the service account to use
+*/}}
+{{- define "binbase.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "binbase.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Create the configs hash
 */}}
 {{- define "machinegun.propertiesHash" -}}

--- a/services/machinegun/templates/_helpers.tpl
+++ b/services/machinegun/templates/_helpers.tpl
@@ -63,17 +63,6 @@ Create the name of the service account to use
 {{- end }}
 
 {{/*
-Create the name of the service account to use
-*/}}
-{{- define "binbase.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create -}}
-    {{ default (include "binbase.fullname" .) .Values.serviceAccount.name }}
-{{- else -}}
-    {{ default "default" .Values.serviceAccount.name }}
-{{- end -}}
-{{- end -}}
-
-{{/*
 Create the configs hash
 */}}
 {{- define "machinegun.propertiesHash" -}}

--- a/services/riak/templates/statefulset.yaml
+++ b/services/riak/templates/statefulset.yaml
@@ -14,6 +14,9 @@ spec:
   template:
     metadata:
       annotations:
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         riak/properties-hash: {{ include "riak.propertiesHash" . }}
       labels:
         app: {{ .Chart.Name }}

--- a/services/riak/values.yaml
+++ b/services/riak/values.yaml
@@ -23,6 +23,8 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name:
 
+podAnnotations: {}
+
 podSecurityContext: {}
   # fsGroup: 2000
 

--- a/services/url-shortener/templates/deployment.yaml
+++ b/services/url-shortener/templates/deployment.yaml
@@ -14,6 +14,9 @@ spec:
       labels:
         {{- include "url-shortener.selectorLabels" . | nindent 8 }}
       annotations:
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         url-shortener/properties-hash: {{ include "url-shortener.propertiesHash" . }}
     spec:
       imagePullSecrets:

--- a/services/url-shortener/templates/serviceaccount.yaml
+++ b/services/url-shortener/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "url-shortener.serviceAccountName" . }}
+  labels:
+    {{- include "url-shortener.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/services/url-shortener/values.yaml
+++ b/services/url-shortener/values.yaml
@@ -12,12 +12,14 @@ fullnameOverride: ""
 
 serviceAccount:
   # Specifies whether a service account should be created
-  create: false
+  create: true
   # Annotations to add to the service account
   annotations: {}
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
   name: ""
+
+podAnnotations: {}
 
 podSecurityContext: {}
   # fsGroup: 2000

--- a/services/wapi-pcidss-v0/templates/_helpers.tpl
+++ b/services/wapi-pcidss-v0/templates/_helpers.tpl
@@ -54,9 +54,9 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{/*
 Create the name of the service account to use
 */}}
-{{- define "machinegun.serviceAccountName" -}}
+{{- define "wapi-pcidss-v0.serviceAccountName" -}}
 {{- if .Values.serviceAccount.create }}
-{{- default (include "machinegun.fullname" .) .Values.serviceAccount.name }}
+{{- default (include "wapi-pcidss-v0.fullname" .) .Values.serviceAccount.name }}
 {{- else }}
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}

--- a/services/wapi-pcidss-v0/templates/_helpers.tpl
+++ b/services/wapi-pcidss-v0/templates/_helpers.tpl
@@ -52,6 +52,17 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
+Create the name of the service account to use
+*/}}
+{{- define "machinegun.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "machinegun.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
 Configs hash
 */}}
 {{- define "wapi-pcidss-v0.propertiesHash" -}}

--- a/services/wapi-pcidss-v0/templates/deployments.yaml
+++ b/services/wapi-pcidss-v0/templates/deployments.yaml
@@ -14,10 +14,14 @@ spec:
       labels:
         {{- include "wapi-pcidss-v0.selectorLabels" . | nindent 8 }}
       annotations:
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         wapi-pcidss-v0/properties-hash: {{ include "wapi-pcidss-v0.propertiesHash" . }}
     spec:
       imagePullSecrets:
         - name: {{ .Values.imagePullSecrets.name }}
+      serviceAccountName: {{ include "machinegun.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       initContainers:

--- a/services/wapi-pcidss-v0/templates/deployments.yaml
+++ b/services/wapi-pcidss-v0/templates/deployments.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       imagePullSecrets:
         - name: {{ .Values.imagePullSecrets.name }}
-      serviceAccountName: {{ include "machinegun.serviceAccountName" . }}
+      serviceAccountName: {{ include "wapi-pcidss-v0.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       initContainers:

--- a/services/wapi-pcidss-v0/templates/serviceaccount.yaml
+++ b/services/wapi-pcidss-v0/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "machinegun.serviceAccountName" . }}
+  labels:
+    {{- include "machinegun.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/services/wapi-pcidss-v0/templates/serviceaccount.yaml
+++ b/services/wapi-pcidss-v0/templates/serviceaccount.yaml
@@ -2,9 +2,9 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "machinegun.serviceAccountName" . }}
+  name: {{ include "wapi-pcidss-v0.serviceAccountName" . }}
   labels:
-    {{- include "machinegun.labels" . | nindent 4 }}
+    {{- include "wapi-pcidss-v0.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/services/wapi-pcidss-v0/values.yaml
+++ b/services/wapi-pcidss-v0/values.yaml
@@ -13,6 +13,17 @@ beam:
 nameOverride: ""
 fullnameOverride: ""
 
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+
 podSecurityContext: {}
   # fsGroup: 2000
 


### PR DESCRIPTION
It looks like service accounts is a default way to manage rights in k8s