### PR TITLE
Remove `pathType` from payform ingress spec

### DIFF
--- a/services/payform/templates/ingress.yaml
+++ b/services/payform/templates/ingress.yaml
@@ -15,7 +15,6 @@ spec:
     http:
       paths:
       - path: {{ .Values.ingress.path }}
-        pathType: Prefix
         backend:
           serviceName: {{ include "payform.fullname" . }}
           servicePort: {{ .Values.service.port }}


### PR DESCRIPTION
Only k8s >= 1.18 supports this field. And GKE doesn't support these versions of k8s