### PR TITLE
add "default" namespace for servicemonitors

### DIFF
--- a/config/prometheus/values.yaml
+++ b/config/prometheus/values.yaml
@@ -5,7 +5,9 @@ prometheus:
       selector:
         matchLabels:
           prometheusmetrics.enabled: "true"
-
+      namespaceSelector:
+        matchNames:
+        - default
       endpoints:
         - port: "api"
           path: /metrics


### PR DESCRIPTION
По умолчанию сервисмонитор ищет сервисы в том же неймспейсе, что и сам сервисмонитор.
Но тут возникает проблема с тем, что стек мониторинга в monitoring, а сервисы деплоятся в default ns.
ПОэтому добавляем сервисмонитору дефолтный неймспейс для поиска