### PR TITLE
10->8gb ram for macs' sake

### DIFF
--- a/tools/cold_reset.sh
+++ b/tools/cold_reset.sh
@@ -1,5 +1,5 @@
 minikube delete &&
-minikube start --cpus=4 --memory="10g" --disk-size="40g" --addons="ingress" --driver="virtualbox" --network-plugin="cni" --extra-config="kubelet.network-plugin=cni" &&
+minikube start --cpus=4 --memory="8g" --disk-size="40g" --addons="ingress" --driver="virtualbox" --network-plugin="cni" --extra-config="kubelet.network-plugin=cni" &&
 minikube ssh -- sudo mount bpffs -t bpf /sys/fs/bpf &&
 kubectl create -f https://raw.githubusercontent.com/cilium/cilium/v1.8/install/kubernetes/quick-install.yaml &&
 kubectl apply -f config/vault/init-cm.yaml


### PR DESCRIPTION
https://forums.virtualbox.org/viewtopic.php?f=8&t=96902
https://forum.parallels.com/threads/no-sound-at-catalina-10-15-2-parallels-desktop-15-1-2-for-mac.349141/

TL;DR
Макось отрубает звук на хостовой системе (да-да), если запущена слишком жирная виртуалка. Кажется не важно каким гипервизором. С 10гб у моего миникуба звук пропадает, с 8 - работает. Нужны тесты, но раз процессинг все равно даже столько не использует, то не вижу причин почем не обрезать. 