### PR TITLE
Delete Init jobs resource after kds and dominanta

### DIFF
--- a/services/dominant/templates/initialization-hook.yaml
+++ b/services/dominant/templates/initialization-hook.yaml
@@ -11,6 +11,7 @@ metadata:
     helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
   annotations:
     "helm.sh/hook": post-install
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
   template:
     metadata:

--- a/services/kds/templates/initialization-hook.yaml
+++ b/services/kds/templates/initialization-hook.yaml
@@ -11,6 +11,7 @@ metadata:
     helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
   annotations:
     "helm.sh/hook": post-install
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
   template:
     metadata:


### PR DESCRIPTION
Косметическое изменение, сносящее job и pod инитов после успешной инициализации, чтобы не висели завершившиеся в error поды.