### PR TITLE
Introduce magista-kafka

### DIFF
--- a/config/magista-kafka/entrypoint.sh
+++ b/config/magista-kafka/entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+set -ue
+
+java \
+    "-XX:OnOutOfMemoryError=kill %p" -XX:+HeapDumpOnOutOfMemoryError \
+    ${@} \
+    --spring.config.additional-location=/vault/secrets/application.properties

--- a/config/magista-kafka/loggers.xml
+++ b/config/magista-kafka/loggers.xml
@@ -1,0 +1,4 @@
+<included>
+    <logger name="com.rbkmoney" level="INFO"/>
+    <logger name="com.rbkmoney.woody" level="INFO"/>
+</included>

--- a/config/magista-kafka/values.yaml.gotmpl
+++ b/config/magista-kafka/values.yaml.gotmpl
@@ -1,0 +1,26 @@
+# -*- mode: yaml -*-
+
+replicaCount: 1
+
+entrypoint: |
+  {{- readFile "entrypoint.sh" | nindent 2 }}
+loggers: |
+  {{- readFile "loggers.xml" | nindent 2 }}
+logback: |
+  {{- readFile "../logs/logback.xml" | nindent 2 }}
+
+podAnnotations:
+  vault.hashicorp.com/role: "db-app"
+  vault.hashicorp.com/agent-inject: "true"
+  vault.hashicorp.com/agent-inject-secret-application.properties: "database/creds/db-app"
+  vault.hashicorp.com/agent-inject-template-application.properties: |
+    {{`
+    {{- with secret "database/creds/db-app" -}}
+    spring.datasource.url=jdbc:postgresql://postgres-postgresql:5432/mst?sslmode=disable
+    spring.datasource.username={{ .Data.username }}
+    spring.datasource.password={{ .Data.password }}
+    flyway.url=jdbc:postgresql://postgres-postgresql:5432/mst?sslmode=disable
+    flyway.user={{ .Data.username }}
+    flyway.password={{ .Data.password }}
+    {{- end }}
+    `}}

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -98,6 +98,15 @@ releases:
   needs:
   - default/vault
   - default/kafka
+- name: magista-kafka
+  <<: *default
+  labels:
+    logfmt: json
+  needs:
+    - default/vault
+    - default/postgres
+    - default/kafka
+  wait: true
 - name: dominant
   <<: *default
   labels:

--- a/services/magista-kafka/.helmignore
+++ b/services/magista-kafka/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/services/magista-kafka/Chart.yaml
+++ b/services/magista-kafka/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: magista-kafka
+description: Magista service (event statistics)
+type: application
+version: 2.0.12
+appVersion: c89d5cae8cf397014828067bcca7e1db1b7078e8

--- a/services/magista-kafka/templates/_helpers.tpl
+++ b/services/magista-kafka/templates/_helpers.tpl
@@ -1,0 +1,69 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "magista-kafka.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "magista-kafka.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "magista-kafka.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "magista-kafka.labels" -}}
+helm.sh/chart: {{ include "magista-kafka.chart" . }}
+{{ include "magista-kafka.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "magista-kafka.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "magista-kafka.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "magista-kafka.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "magista-kafka.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Configs hash
+*/}}
+{{- define "magista-kafka.propertiesHash" -}}
+{{- include (print $.Template.BasePath "/configmap.yaml") . | sha256sum -}}
+{{- end -}}

--- a/services/magista-kafka/templates/configmap.yaml
+++ b/services/magista-kafka/templates/configmap.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "magista-kafka.fullname" . }}
+  labels:
+    {{- include "magista-kafka.labels" . | nindent 4 }}
+data:
+  entrypoint.sh: |
+    {{- .Values.entrypoint | nindent 4 }}
+  logback.xml: |
+    {{- .Values.logback | nindent 4 }}
+  loggers.xml: |
+    {{- .Values.loggers | nindent 4 }}

--- a/services/magista-kafka/templates/deployment.yaml
+++ b/services/magista-kafka/templates/deployment.yaml
@@ -1,0 +1,124 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "magista-kafka.fullname" . }}
+  labels:
+    {{- include "magista-kafka.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "magista-kafka.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+      {{- include "magista-kafka.selectorLabels" . | nindent 8 }}
+      annotations:
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        magista-kafka/properties-hash: {{ include "magista-kafka.propertiesHash" . }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "magista-kafka.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: api
+              containerPort: {{ .Values.service.ports.api }}
+              protocol: TCP
+            - name: management
+              containerPort: {{ .Values.service.ports.management }}
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /actuator/health
+              port: management
+            initialDelaySeconds: 120
+            timeoutSeconds: 3
+            periodSeconds: 30
+            successThreshold: 1
+            failureThreshold: 5
+          readinessProbe:
+            httpGet:
+              path: /actuator/health
+              port: management
+            initialDelaySeconds: 120
+            timeoutSeconds: 3
+            periodSeconds: 30
+            successThreshold: 1
+            failureThreshold: 5
+          volumeMounts:
+            - name: config-volume
+              mountPath: /opt/magista-kafka/entrypoint.sh
+              subPath: entrypoint.sh
+              readOnly: true
+            - name: config-volume
+              mountPath: /opt/magista-kafka/logback.xml
+              subPath: logback.xml
+              readOnly: true
+            - name: config-volume
+              mountPath: /opt/magista-kafka/loggers.xml
+              subPath: loggers.xml
+              readOnly: true
+          command: ["/opt/magista-kafka/entrypoint.sh"]
+          args:
+            - -jar
+            - /opt/magista/magista.jar
+            - --logging.config=/opt/magista-kafka/logback.xml
+            - --spring.application.name=magista-kafka
+            - --spring.datasource.hikari.maximum-pool-size={{ .Values.datasource.poolsize }}
+            - --spring.datasource.hikari.data-source-properties.prepareThreshold=0
+            - --spring.datasource.hikari.leak-detection-threshold=5300
+            - --spring.datasource.hikari.max-lifetime=300000
+            - --spring.datasource.hikari.idle-timeout=30000
+            - --spring.datasource.hikari.minimum-idle=2
+            - --flyway.schemas=mst
+            - --payouter.pooling.url=http://payouter:8022/repo
+            - --hellgate.url=http://hellgate:8022/v1/processing/partymgmt
+            - --hellgate.timeout=30000
+            - --columbus.url=http://columbus:8022/repo
+            - --retry-policy.maxAttempts=-1
+            - --kafka.bootstrap-servers={{ .Values.kafka.bootstrapServers }}
+            - --kafka.topics.invoicing={{ .Values.kafka.topicInvoiceName }}
+            - --kafka.client-id=magista
+            - --kafka.consumer.group-id=magista-invoicing-1
+            - --kafka.consumer.concurrency=7
+          env:
+            - name: LOGBACK_SERVICE_NAME
+              value: "magista-kafka"
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      volumes:
+        - name: config-volume
+          configMap:
+            name: {{ include "magista-kafka.fullname" . }}
+            items:
+              - key: entrypoint.sh
+                path: entrypoint.sh
+                mode: 0755
+              - key: logback.xml
+                path: logback.xml
+              - key: loggers.xml
+                path: loggers.xml
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/services/magista-kafka/templates/service.yaml
+++ b/services/magista-kafka/templates/service.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "magista-kafka.fullname" . }}
+  labels:
+    {{- include "magista-kafka.labels" . | nindent 4 }}
+  {{- with .Values.podLabels }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.ports.api }}
+      targetPort: api
+      protocol: TCP
+      name: api
+    - port: {{ .Values.service.ports.management }}
+      targetPort: management
+      protocol: TCP
+      name: management
+  selector:
+    {{- include "magista-kafka.selectorLabels" . | nindent 4 }}

--- a/services/magista-kafka/templates/serviceaccount.yaml
+++ b/services/magista-kafka/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "magista-kafka.serviceAccountName" . }}
+  labels:
+    {{- include "magista-kafka.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/services/magista-kafka/templates/tests/test-connection.yaml
+++ b/services/magista-kafka/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "magista-kafka.fullname" . }}-test-connection"
+  labels:
+    {{- include "magista-kafka.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test-success
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "magista-kafka.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/services/magista-kafka/values.yaml
+++ b/services/magista-kafka/values.yaml
@@ -1,0 +1,66 @@
+image:
+  repository: docker.io/rbkmoney/magista
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+
+replicaCount: 1
+
+nameOverride: ""
+fullnameOverride: ""
+
+podSecurityContext: {}
+# fsGroup: 2000
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+
+podLabels:
+  prometheus.metrics.java.enabled: "true"
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+# runAsUser: 1000
+
+service:
+  type: ClusterIP
+  ports:
+    api: 8022
+    management: 8023
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+#   memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+kafka:
+  bootstrapServers: kafka-headless:9092
+  topicInvoiceName: mg-events-invoice
+
+datasource:
+  poolsize: 20


### PR DESCRIPTION
Пожалуйста, проверьте корректность конфигурации: пока нет 100% понимания того, как все сделать как положено.

**Нюансы:**

- Сервис собирается из образа `magista`, хотя и называется `magista-kafka`
- У сервиса должно быть подключение к PG, нужно создать базу `mst`
- У сервиса должен быть доступ к Кафке – топик `mg-events-invoice`
- У сервиса должен быть доступ до `columbus`, `payouter` и `hellgate`
